### PR TITLE
Resolve a NU1608 warning in the CrossSiteApprovals

### DIFF
--- a/CrossSiteApprovals/CrossSiteApprovalsFunctions/CrossSiteApprovalsFunctions.csproj
+++ b/CrossSiteApprovals/CrossSiteApprovalsFunctions/CrossSiteApprovalsFunctions.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>CPS.CrossSiteApprovalsFunctions</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.24" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SharePoint.WebHooks.Common\SharePoint.WebHooks.Common.csproj" />

--- a/CrossSiteApprovals/SharePoint.WebHooks.Common.Tests/packages.config
+++ b/CrossSiteApprovals/SharePoint.WebHooks.Common.Tests/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net462" />
-  <package id="Microsoft.Azure.WebJobs" version="2.2.0" targetFramework="net462" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.2.0" targetFramework="net462" />
+  <package id="Microsoft.Azure.WebJobs" version="3.0.0" targetFramework="net462" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="3.0.0" targetFramework="net462" />
   <package id="Microsoft.Data.Edm" version="5.8.4" targetFramework="net462" />
   <package id="Microsoft.Data.OData" version="5.8.4" targetFramework="net462" />
   <package id="Microsoft.Data.Services.Client" version="5.8.4" targetFramework="net462" />

--- a/CrossSiteApprovals/SharePoint.WebHooks.Common/packages.config
+++ b/CrossSiteApprovals/SharePoint.WebHooks.Common/packages.config
@@ -5,8 +5,8 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net461" />
   <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.1.0" targetFramework="net461" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs" version="2.2.0" targetFramework="net461" />
-  <package id="Microsoft.Azure.WebJobs.Core" version="2.2.0" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs" version="3.0.0" targetFramework="net461" />
+  <package id="Microsoft.Azure.WebJobs.Core" version="3.0.0" targetFramework="net461" />
   <package id="Microsoft.Data.Edm" version="5.8.4" targetFramework="net461" />
   <package id="Microsoft.Data.OData" version="5.8.4" targetFramework="net461" />
   <package id="Microsoft.Data.Services.Client" version="5.8.4" targetFramework="net461" />
@@ -22,7 +22,7 @@
   <package id="Microsoft.SharePointOnline.CSOM" version="16.1.19223.12000" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net461" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net461" />
   <package id="SharePointPnP.IdentityModel.Extensions" version="1.2.4" targetFramework="net461" />
   <package id="SharePointPnPCoreOnline" version="3.13.1909" targetFramework="net461" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
Hi@realwillwright, I found a NU1608 warning in the CrossSiteApprovals:

`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.NET.Sdk.Functions 1.0.24 requires Newtonsoft.Json (= 9.0.1)，but version Newtonsoft.Json 11.0.1 was resolved.`

This fix can remove this warnings from CrossSiteApprovals's dependency graph.
Hope the PR can help you.

Best regards,
sucrose